### PR TITLE
Add Delete Message and Delete Attachment Functionality

### DIFF
--- a/app/src/main/java/com/nicolashurtado/messagingapp/db/daos/AttachmentDao.kt
+++ b/app/src/main/java/com/nicolashurtado/messagingapp/db/daos/AttachmentDao.kt
@@ -1,6 +1,7 @@
 package com.nicolashurtado.messagingapp.db.daos
 
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import com.nicolashurtado.messagingapp.db.entities.Attachment
 
@@ -8,4 +9,7 @@ import com.nicolashurtado.messagingapp.db.entities.Attachment
 interface AttachmentDao {
     @Insert
     fun insertAll(vararg attachments: Attachment)
+
+    @Delete
+    fun delete(attachment: Attachment)
 }

--- a/app/src/main/java/com/nicolashurtado/messagingapp/db/daos/MessageDao.kt
+++ b/app/src/main/java/com/nicolashurtado/messagingapp/db/daos/MessageDao.kt
@@ -2,6 +2,7 @@ package com.nicolashurtado.messagingapp.db.daos
 
 import androidx.paging.DataSource
 import androidx.room.Dao
+import androidx.room.Delete
 import androidx.room.Insert
 import androidx.room.Query
 import com.nicolashurtado.messagingapp.db.entities.Message
@@ -13,4 +14,7 @@ interface MessageDao {
 
     @Insert
     fun insertAll(vararg messages: Message)
+
+    @Delete
+    fun delete(message : Message)
 }

--- a/app/src/main/java/com/nicolashurtado/messagingapp/ui/activities/MessagingActivity.kt
+++ b/app/src/main/java/com/nicolashurtado/messagingapp/ui/activities/MessagingActivity.kt
@@ -2,18 +2,21 @@ package com.nicolashurtado.messagingapp.ui.activities
 
 import android.os.Bundle
 import android.widget.ProgressBar
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.nicolashurtado.messagingapp.BuildConfig.DATA_SEED_FILE_NAME
 import com.nicolashurtado.messagingapp.R
+import com.nicolashurtado.messagingapp.db.entities.Attachment
+import com.nicolashurtado.messagingapp.db.entities.Message
 import com.nicolashurtado.messagingapp.ui.adapters.MessageAdapter
 import com.nicolashurtado.messagingapp.ui.adapters.PublicationDiffUtil
 import com.nicolashurtado.messagingapp.ui.viewmodels.MessageViewModel
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
-class MessagingActivity : AppCompatActivity() {
+class MessagingActivity : AppCompatActivity(), MessageAdapter.OnMessageLongClickListener {
 
     private val viewModel: MessageViewModel by viewModel()
     private val recyclerView: RecyclerView by lazy { findViewById<RecyclerView>(R.id.recycler_view) }
@@ -26,7 +29,7 @@ class MessagingActivity : AppCompatActivity() {
 
         //TODO Move data loading outside the activity to avoid issues when the screen gets recreated.
         viewModel.loadData(DATA_SEED_FILE_NAME)
-        val adapter = MessageAdapter(PublicationDiffUtil()).apply {
+        val adapter = MessageAdapter(PublicationDiffUtil(), this).apply {
             setHasStableIds(true)
         }
 
@@ -38,4 +41,30 @@ class MessagingActivity : AppCompatActivity() {
         })
     }
 
+    override fun onAttachmentClicked(attachment: Attachment) {
+        AlertDialog.Builder(this)
+                .setTitle(R.string.txt_title_delete_attachment_confirmation)
+                .setCancelable(true)
+                .setPositiveButton(R.string.txt_delete_button) { _, _ ->
+                    viewModel.deleteAttachment(attachment)
+                }
+                .setNegativeButton(android.R.string.cancel) { dialog, _ ->
+                    dialog.dismiss()
+                }
+                .show()
+    }
+
+    override fun onMessageClicked(message: Message) {
+        AlertDialog.Builder(this)
+                .setTitle(R.string.txt_title_delete_message_confirmation)
+                .setCancelable(true)
+                .setPositiveButton(R.string.txt_delete_button) { _, _ ->
+                    viewModel.deleteMessage(message)
+                }
+                .setNegativeButton(android.R.string.cancel) { dialog, _ ->
+                    dialog.dismiss()
+                }
+                .show()
+
+    }
 }

--- a/app/src/main/java/com/nicolashurtado/messagingapp/ui/activities/MessagingActivity.kt
+++ b/app/src/main/java/com/nicolashurtado/messagingapp/ui/activities/MessagingActivity.kt
@@ -65,6 +65,5 @@ class MessagingActivity : AppCompatActivity(), MessageAdapter.OnMessageLongClick
                     dialog.dismiss()
                 }
                 .show()
-
     }
 }

--- a/app/src/main/java/com/nicolashurtado/messagingapp/ui/adapters/MessageAdapter.kt
+++ b/app/src/main/java/com/nicolashurtado/messagingapp/ui/adapters/MessageAdapter.kt
@@ -4,17 +4,26 @@ import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.paging.PagedListAdapter
 import com.nicolashurtado.messagingapp.R
+import com.nicolashurtado.messagingapp.db.entities.Attachment
+import com.nicolashurtado.messagingapp.db.entities.Message
 import com.nicolashurtado.messagingapp.db.entities.Publication
 import com.nicolashurtado.messagingapp.ui.viewholders.ExternalMessageViewHolder
 import com.nicolashurtado.messagingapp.ui.viewholders.MessageViewHolder
 
-class MessageAdapter(diffUtil: PublicationDiffUtil) : PagedListAdapter<Publication, MessageViewHolder>(diffUtil) {
+class MessageAdapter(diffUtil: PublicationDiffUtil, private val listener : OnMessageLongClickListener) :
+        PagedListAdapter<Publication, MessageViewHolder>(diffUtil), MessageViewHolder.OnMessageLongClickListener {
+
+    interface OnMessageLongClickListener {
+        fun onAttachmentClicked(attachment : Attachment)
+        fun onMessageClicked(message : Message)
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MessageViewHolder {
         val inflater = LayoutInflater.from(parent.context)
         return when (viewType) {
-            R.layout.item_external_message -> ExternalMessageViewHolder(inflater.inflate(viewType, parent, false))
-            R.layout.item_message -> MessageViewHolder(inflater.inflate(viewType, parent, false))
-            else -> MessageViewHolder(inflater.inflate(R.layout.item_message, parent, false))
+            R.layout.item_external_message -> ExternalMessageViewHolder(inflater.inflate(viewType, parent, false), this)
+            R.layout.item_message -> MessageViewHolder(inflater.inflate(viewType, parent, false), this)
+            else -> MessageViewHolder(inflater.inflate(R.layout.item_message, parent, false), this)
         }
     }
 
@@ -38,4 +47,17 @@ class MessageAdapter(diffUtil: PublicationDiffUtil) : PagedListAdapter<Publicati
         }
     }
 
+    override fun onAttachmentClicked(pos: Int, attachmentId : String) {
+        getItem(pos)?.attachments?.firstOrNull {
+            it.id == attachmentId
+        }?.let {
+            listener.onAttachmentClicked(it)
+        }
+    }
+
+    override fun onMessageClicked(pos: Int) {
+        getItem(pos)?.message?.let {
+            listener.onMessageClicked(it)
+        }
+    }
 }

--- a/app/src/main/java/com/nicolashurtado/messagingapp/ui/viewholders/ExternalMessageViewHolder.kt
+++ b/app/src/main/java/com/nicolashurtado/messagingapp/ui/viewholders/ExternalMessageViewHolder.kt
@@ -7,7 +7,8 @@ import com.nicolashurtado.messagingapp.db.entities.Publication
 import com.nicolashurtado.messagingapp.ui.CircleTransformation
 import com.squareup.picasso.Picasso
 
-class ExternalMessageViewHolder(view: View) : MessageViewHolder(view) {
+class ExternalMessageViewHolder(view: View, listener: OnMessageLongClickListener) :
+        MessageViewHolder(view, listener) {
 
     private val userImageView by lazy { itemView.findViewById<ImageView>(R.id.image_view_user) }
 

--- a/app/src/main/java/com/nicolashurtado/messagingapp/ui/viewholders/MessageViewHolder.kt
+++ b/app/src/main/java/com/nicolashurtado/messagingapp/ui/viewholders/MessageViewHolder.kt
@@ -11,13 +11,26 @@ import com.nicolashurtado.messagingapp.db.entities.Attachment
 import com.nicolashurtado.messagingapp.db.entities.Publication
 import com.squareup.picasso.Picasso
 
-open class MessageViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+open class MessageViewHolder(view: View, private val listener: OnMessageLongClickListener) :
+        RecyclerView.ViewHolder(view) {
+
+    interface OnMessageLongClickListener {
+        fun onAttachmentClicked(pos: Int, attachmentId: String)
+        fun onMessageClicked(pos: Int)
+    }
 
     protected val userNameTextView by lazy { itemView.findViewById<TextView>(R.id.text_view_user_name) }
     protected val contentTextView by lazy { itemView.findViewById<TextView>(R.id.text_view_content) }
     protected val attachmentsLayout by lazy { itemView.findViewById<LinearLayout>(R.id.layout_attachments) }
 
     open fun bind(publication: Publication) {
+        itemView.setOnLongClickListener {
+            val pos = adapterPosition
+            if (pos != RecyclerView.NO_POSITION) {
+                listener.onMessageClicked(pos)
+            }
+            true
+        }
         userNameTextView.text = itemView.context.getString(R.string.txt_me)
         contentTextView.text = publication.message.content
         if (publication.attachments.isEmpty()) {
@@ -35,6 +48,14 @@ open class MessageViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         val attachmentView = LayoutInflater.from(attachmentsLayout.context).inflate(R.layout.item_attachment, attachmentsLayout, false)
         val attachmentImageView = attachmentView.findViewById<ImageView>(R.id.image_view_attachment_thumbnail)
         val attachmentNameTextView = attachmentView.findViewById<TextView>(R.id.text_view_attachment_name)
+
+        attachmentView.setOnLongClickListener {
+            val pos = adapterPosition
+            if (pos != RecyclerView.NO_POSITION) {
+                listener.onAttachmentClicked(pos, attachment.id)
+            }
+            true
+        }
 
         attachmentNameTextView.text = attachment.title
         if (attachment.thumbnailUrl.isNotEmpty()) {

--- a/app/src/main/java/com/nicolashurtado/messagingapp/ui/viewmodels/MessageViewModel.kt
+++ b/app/src/main/java/com/nicolashurtado/messagingapp/ui/viewmodels/MessageViewModel.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.ViewModel
 import androidx.paging.LivePagedListBuilder
 import androidx.paging.PagedList
 import com.nicolashurtado.messagingapp.db.MessagingDatabase
+import com.nicolashurtado.messagingapp.db.entities.Attachment
+import com.nicolashurtado.messagingapp.db.entities.Message
 import com.nicolashurtado.messagingapp.db.entities.Publication
 import com.nicolashurtado.messagingapp.loader.DataLoader
 import kotlinx.coroutines.CoroutineScope
@@ -47,5 +49,17 @@ class MessageViewModel(private val database: MessagingDatabase, private val data
 
     fun getPublications(): LiveData<PagedList<Publication>> {
         return publicationsLiveData
+    }
+
+    fun deleteMessage(message: Message) {
+        CoroutineScope(Dispatchers.IO).launch {
+            database.messageDao().delete(message)
+        }
+    }
+
+    fun deleteAttachment(attachment: Attachment) {
+        CoroutineScope(Dispatchers.IO).launch {
+            database.attachmentDao().delete(attachment)
+        }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,7 @@
     <string name="app_name">MessagingApp</string>
     <string name="txt_me">Me</string>
     <string name="activity_messages_label">Messages</string>
+    <string name="txt_title_delete_attachment_confirmation">Delete attachment?</string>
+    <string name="txt_title_delete_message_confirmation">Delete message?</string>
+    <string name="txt_delete_button">Delete</string>
 </resources>


### PR DESCRIPTION
## WHAT'S IN

- Added code to the Attachment and Message DAO to allow deletion of these entities.
- Added interfaces and code to listen for the long clicks on the messages and attachments.
- Added code to display alert dialog to confirm deletion action for both messages and attachments.

![screenshot_1549928517](https://user-images.githubusercontent.com/5490212/52601511-08598000-2e2d-11e9-9da1-3db8d7dc6bcb.png)