### PR TITLE
Attachments Binding Fix

### DIFF
--- a/app/src/main/java/com/nicolashurtado/messagingapp/ui/viewholders/MessageViewHolder.kt
+++ b/app/src/main/java/com/nicolashurtado/messagingapp/ui/viewholders/MessageViewHolder.kt
@@ -33,8 +33,9 @@ open class MessageViewHolder(view: View, private val listener: OnMessageLongClic
         }
         userNameTextView.text = itemView.context.getString(R.string.txt_me)
         contentTextView.text = publication.message.content
+        attachmentsLayout.removeAllViews()
+
         if (publication.attachments.isEmpty()) {
-            attachmentsLayout.removeAllViews()
             attachmentsLayout.visibility = View.GONE
         } else {
             attachmentsLayout.visibility = View.VISIBLE


### PR DESCRIPTION
## WHAT'S IN
- Added fix to the attachments binding on the MessageViewHolder to avoid duplicates and clear them each time the binding method is called.